### PR TITLE
small patch to say which avsc file failed, instead of saying `Failed to parse at least one .avsc file`

### DIFF
--- a/codegen/src/main/scala/com/nitro/scalaAvro/codegen/AvroRoot.scala
+++ b/codegen/src/main/scala/com/nitro/scalaAvro/codegen/AvroRoot.scala
@@ -45,7 +45,7 @@ object AvroRoot {
         val namespacePath = namespace.split("\\.").mkString(File.separator)
         val fileDest = new File(dest.getAbsolutePath + File.separator + namespacePath)
         fileDest.mkdirs()
-        val path = Paths.get(fileDest.getAbsolutePath , name)
+        val path = Paths.get(fileDest.getAbsolutePath, name)
         val bytes = printer.result().getBytes(StandardCharsets.UTF_8)
         log.info(s"writing output for name: $name to $path")
         Files.write(path, bytes)

--- a/codegen/src/main/scala/com/nitro/scalaAvro/codegen/SchemaParser.scala
+++ b/codegen/src/main/scala/com/nitro/scalaAvro/codegen/SchemaParser.scala
@@ -9,13 +9,28 @@ import org.apache.avro.Schema.Type._
 import org.apache.avro.file.DataFileReader
 import org.apache.avro.generic.{ GenericDatumReader, GenericRecord }
 import java.io.File
+
 import RichAvro._
 
 import collection.JavaConversions._
 import collection.JavaConverters._
-import scala.util.{ Failure, Try }
+import scala.util.{ Failure, Success, Try }
 
 object SchemaParser {
+  lazy val checkSanity = (avscDocs: Iterable[File], parserForAvsc: Parser) => {
+    avscDocs.map {
+      avscDoc =>
+        {
+          val avscStr = new String(Files.readAllBytes(avscDoc.toPath))
+          Try(parserForAvsc.parse(avscStr)) match {
+            case Failure(e) =>
+              println(s"Failed to parse $avscDoc")
+              throw e
+            case Success(schema) =>
+          }
+        }
+    }
+  }
   //map package name to schema
   def getSchemas(files: Iterable[File]): Seq[(String, Either[AvroRecord, AvroEnum])] = {
     val parserForAvsc = new Parser()
@@ -24,18 +39,22 @@ object SchemaParser {
       import spray.json._
       import PartialAvroJsonProtocol._
 
+      val avscDocs = files
+        .filter(_.getName.endsWith("avsc"))
+
       val avscStrs =
-        files
-          .filter(_.getName.endsWith("avsc"))
+        avscDocs
           .map { fi => new String(Files.readAllBytes(fi.toPath)) }
 
-      Try(avscStrs.map { parserForAvsc.parse }) match {
+      checkSanity(avscDocs, parserForAvsc)
+
+      /*     Try(avscStrs.map { parserForAvsc.parse }) match {
         case Failure(e) =>
           println("Failed to parse at least one .avsc file")
           throw e
 
         case _ =>
-      }
+      }*/
 
       val avspStrs =
         files

--- a/codegen/src/main/scala/com/nitro/scalaAvro/codegen/SchemaParser.scala
+++ b/codegen/src/main/scala/com/nitro/scalaAvro/codegen/SchemaParser.scala
@@ -35,27 +35,15 @@ object SchemaParser {
   def getSchemas(files: Iterable[File]): Seq[(String, Either[AvroRecord, AvroEnum])] = {
     val parserForAvsc = new Parser()
     val schemas: Seq[Schema] = {
-
       import spray.json._
       import PartialAvroJsonProtocol._
-
       val avscDocs = files
         .filter(_.getName.endsWith("avsc"))
-
       val avscStrs =
         avscDocs
           .map { fi => new String(Files.readAllBytes(fi.toPath)) }
 
       checkSanity(avscDocs, parserForAvsc)
-
-      /*     Try(avscStrs.map { parserForAvsc.parse }) match {
-        case Failure(e) =>
-          println("Failed to parse at least one .avsc file")
-          throw e
-
-        case _ =>
-      }*/
-
       val avspStrs =
         files
           .filter(_.getName.endsWith("avsp"))

--- a/codegen/src/test/scala/com/nitro/scalaAvro/AvModuleSpec.scala
+++ b/codegen/src/test/scala/com/nitro/scalaAvro/AvModuleSpec.scala
@@ -11,8 +11,6 @@ import java.nio.file.Paths
 import java.nio.file.Files
 import java.nio.file.StandardOpenOption
 
-import com.nitro.scalaAvro.codegen.SchemaParser
-
 class AvModuleSpec extends PropSpec with Matchers {
   def bounce(avsc: AvSchema): AvSchema =
     avsc.toJson.toString.parseJson.convertTo[AvSchema]

--- a/codegen/src/test/scala/com/nitro/scalaAvro/AvModuleSpec.scala
+++ b/codegen/src/test/scala/com/nitro/scalaAvro/AvModuleSpec.scala
@@ -1,12 +1,17 @@
 package com.nitro.scalaAvro
 
+import java.io.File
+
 import org.scalatest._
 import spray.json._
 import PartialAvroJsonProtocol._
+
 import language.reflectiveCalls
 import java.nio.file.Paths
 import java.nio.file.Files
 import java.nio.file.StandardOpenOption
+
+import com.nitro.scalaAvro.codegen.SchemaParser
 
 class AvModuleSpec extends PropSpec with Matchers {
   def bounce(avsc: AvSchema): AvSchema =

--- a/project/SharedForBuild.scala
+++ b/project/SharedForBuild.scala
@@ -10,7 +10,7 @@ object SharedForBuild extends Build {
   import com.nitro.build._
   import PublishHelpers._
 
-  lazy val semver = SemanticVersion(0, 3, 4, isSnapshot = false)
+  lazy val semver = SemanticVersion(0, 3, 5, isSnapshot = false)
 
   lazy val apacheAvroDep = "org.apache.avro" % "avro" % "1.8.1"
 


### PR DESCRIPTION
refer to https://github.com/Nitro/avro-codegen/issues/23 
